### PR TITLE
Cleanup codesmells reported by SonarCloud in TorpedoStore

### DIFF
--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -14,6 +14,8 @@ public class TorpedoStore {
 
   private int torpedoCount = 0;
 
+  private Random generator = new Random();
+
   public TorpedoStore(int numberOfTorpedos){
     this.torpedoCount = numberOfTorpedos;
 
@@ -36,7 +38,6 @@ public class TorpedoStore {
     boolean success = false;
 
     // simulate random overheating of the launcher bay which prevents firing
-    Random generator = new Random();
     double r = generator.nextDouble();
 
     if (r >= FAILURE_RATE) {

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -42,7 +42,7 @@ public class TorpedoStore {
 
     if (r >= FAILURE_RATE) {
       // successful firing
-      this.torpedoCount =- numberOfTorpedos;
+      this.torpedoCount -= numberOfTorpedos;
       success = true;
     } else {
       // simulated failure

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -28,9 +28,9 @@ public class TorpedoStore {
     }
   }
 
-  public boolean fire(int numberOfTorpedos){
+  public boolean fire(int numberOfTorpedos) throws IllegalArgumentException {
     if(numberOfTorpedos < 1 || numberOfTorpedos > this.torpedoCount){
-      new IllegalArgumentException("numberOfTorpedos");
+      throw new IllegalArgumentException("numberOfTorpedos");
     }
 
     boolean success = false;

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -14,7 +14,7 @@ public class TorpedoStore {
 
   private int torpedoCount = 0;
 
-  private Random generator = new Random();
+  private Random generator = new Random(6969L);
 
   public TorpedoStore(int numberOfTorpedos){
     this.torpedoCount = numberOfTorpedos;


### PR DESCRIPTION
The following errors reported by SonarCloud have been fixed by this PR:
- Throw this exception or remove this useless statement.
- Save and re-use this "Random".
- Was "-=" meant instead?